### PR TITLE
Fix bounds for integration over \theta

### DIFF
--- a/02-te/02-4-simplifications.tex
+++ b/02-te/02-4-simplifications.tex
@@ -140,7 +140,7 @@ We next assume (which is often true) that our systems is \textbf{azimuthally sym
 We will use these terms in our simplifications:\\
 $d\vOmega = \sin(\theta) d\theta d\varphi = d\mu d\varphi; \quad \mu = \cos(\theta)\,$ so $d\mu = \sin(\theta)d\theta\:; \quad \Omega_z = \cos(\theta) = \mu\:.$
 \begin{align*}
-\int_{4 \pi} d\vOmega &= \int_0^{2\pi} d\varphi \int_{-\pi/2}^{\pi/2} \sin(\theta) d\theta =  \int_0^{2\pi} d\varphi \int_{-1}^1 d\mu = 4\pi \\
+\int_{4 \pi} d\vOmega &= \int_0^{2\pi} d\varphi \int_{0}^{\pi} \sin(\theta) d\theta =  \int_0^{2\pi} d\varphi \int_{-1}^1 d\mu = 4\pi \\
 \psi(z,\vOmega,E,t) d\vOmega &= \psi(z,\varphi, \mu,E,t) d\varphi  d\mu =  \psi(z, \mu,E,t) d\varphi  d\mu 
 \end{align*}
 %


### PR DESCRIPTION
\theta is defined from 0 to pi, not -pi/2 to pi/2. Otherwise the integral of sin(\theta)d\theta would give zero. This is the first time I'm trying to propose a change to someone else's repository so forgive me if I'm not doing this correctly...
