### PR TITLE
Replace \approx by =

### DIFF
--- a/04-discretization/04-discretization.tex
+++ b/04-discretization/04-discretization.tex
@@ -501,7 +501,7 @@ As mentioned, the other approach is using Spherical Harmonics more broadly. In t
 
 We will use
 \[
-\psi(x, \mu) \approx \sum_{l=0}^{\infty} \frac{(2l+1)}{4\pi} \phi_l(x)P_l(\mu)
+\psi(x, \mu) = \sum_{l=0}^{\infty} \frac{(2l+1)}{4\pi} \phi_l(x)P_l(\mu)
 \]
 for the flux solution in total. This next part comes from Appendix D of L\&M with the normalizations made to be consistent with what we did last class. Note that some people normalize to 1 and some to $4\pi$, which changes the constants. I'll try to be consistent... We start with the within group, 1D TE
 \[


### PR DESCRIPTION
Legendre expansion is exact until you truncate the series since the Legendre polynomials form a basis over [-1,1].
